### PR TITLE
Workflows commit via FPH Service Account

### DIFF
--- a/.github/workflows/update-binaries-esp32.yaml
+++ b/.github/workflows/update-binaries-esp32.yaml
@@ -46,11 +46,11 @@ jobs:
 
     - name: Add and commit release assets to the current repository
       run: |
-        git config --global user.name 'GitHub Actions Bot'
-        git config --global user.email 'actions@github.com'
+        git config --global user.name 'fph-service-account'
+        git config --global user.email 'github-service-account-group@futureproofhomes.net'
         git add ./assets/*
         git add ./manifests/*
         git commit -m "Add ESPHome Firmware: ${{ github.event.inputs.esphome_release_tag }}"
         git push
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/update-binaries-xmos.yaml
+++ b/.github/workflows/update-binaries-xmos.yaml
@@ -39,11 +39,10 @@ jobs:
 
     - name: Add and commit release assets to the current repository
       run: |
-        git config --global user.name 'GitHub Actions Bot'
-        git config --global user.email 'actions@github.com'
+        git config --global user.name 'fph-service-account'
+        git config --global user.email 'github-service-account-group@futureproofhomes.net'
         git add ./assets/*
         git commit -m "Add XMOS Firmware: ${{ github.event.inputs.xmos_release_tag }}"
         git push
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
- We have enabled branch protection rules on the /Documentation repo, which broke the ability for Github Actions Bot to commit to repo.
- I am attempting to perform this commit via our FPH service account which has exception permissions in the branch protection rules.