### PR TITLE
Reenable XMOS binary storage in documentation repository

### DIFF
--- a/.github/workflows/update-binaries-xmos.yaml
+++ b/.github/workflows/update-binaries-xmos.yaml
@@ -1,0 +1,48 @@
+name: Download and Commit Release from XMOS Repo
+on:
+  workflow_dispatch:  # Allows manual trigger of the workflow
+    inputs:
+      xmos_release_tag:
+        description: 'Tag of the XMOS release firmware to download'
+        required: true
+env:
+  esphome_repo: FutureProofHomes/Satellite1-ESPHome
+  xmos_repo: FutureProofHomes/Satellite1-XMOS
+jobs:
+  download-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout current repository
+      uses: actions/checkout@v4
+
+    - name: Authenticate with GitHub CLI
+      run: |
+        echo "${{ secrets.PAT_TOKEN }}" | gh auth login --with-token
+
+    - name: Download XMOS release asset
+      run: |
+        mkdir -p ./assets/firmware/xmos/${{ github.event.inputs.xmos_release_tag }}
+        gh release download ${{ github.event.inputs.xmos_release_tag }} \
+        --repo ${{ env.xmos_repo }} \
+        --dir ./assets/firmware/xmos/${{ github.event.inputs.xmos_release_tag }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+    - name: unzip the XMOS release asset
+      run: |
+          cd ./assets/firmware/xmos/${{ github.event.inputs.xmos_release_tag }}
+          unzip *.zip
+          rm *.zip
+          tree
+
+    - name: Add and commit release assets to the current repository
+      run: |
+        git config --global user.name 'GitHub Actions Bot'
+        git config --global user.email 'actions@github.com'
+        git add ./assets/*
+        git commit -m "Add XMOS Firmware: ${{ github.event.inputs.xmos_release_tag }}"
+        git push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Restore the workflow for downloading and committing XMOS release firmware assets to the documentation repository. 