### PR TITLE
Adding PAT_TOKEN back

### DIFF
--- a/.github/workflows/update-binaries-esp32.yaml
+++ b/.github/workflows/update-binaries-esp32.yaml
@@ -20,6 +20,7 @@ jobs:
     - name: Create manifest files for each hardware revision
       run: |
         chmod +x ./scripts/create_manifest.sh
+        export GITHUB_TOKEN=${{ secrets.PAT_TOKEN }}
         ./scripts/create_manifest.sh ${{ github.event.inputs.esphome_release_tag }} ${{ env.esphome_repo }}
 
     - name: Add and commit release assets to the current repository


### PR DESCRIPTION
Resolved the issue and updated the manifest file. After further investigation, including the PAT_TOKEN was not the root cause of the problem. Re-adding the PAT_TOKEN to support future access to private repositories.