### PR TITLE
Update manifest generation to use release Summary section

### DIFF
--- a/scripts/create_manifest.py
+++ b/scripts/create_manifest.py
@@ -21,6 +21,7 @@ def process_build(
     beta,
     release_repository,
     GITHUB_TOKEN,
+    release_summary,
 ):
     # Get the Asset ID for the OTA binaries
     # Sample URL: https://api.github.com/repos/FutureProofHomes/Satellite1-ESPHome/releases/assets/210089213
@@ -40,9 +41,8 @@ def process_build(
             "Accept": "application/octet-stream",
             "X-GitHub-Api-Version": "2022-11-28",
         }
-    if not GITHUB_TOKEN is None:
+    if GITHUB_TOKEN:
         headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
-    
     ota_request = urllib.request.Request(OTA_DOWNLOAD_URL, headers=headers)
     if BROWSER_URL_OTA:
         try:
@@ -64,6 +64,7 @@ def process_build(
         MANIFEST_FILE_DIR=MANIFEST_FILE_DIR,
         beta=beta,
         FIRMWARE_FILE_DIR=FIRMWARE_FILE_DIR.split("../")[-1],
+        summary=release_summary,
     )
     utils.download_release(BROWSER_URL_OTA, beta, FIRMWARE_FILE_DIR)
     utils.download_release(BROWSER_URL_FACTORY, beta, FIRMWARE_FILE_DIR)
@@ -79,9 +80,10 @@ def main():
     release_tag = sys.argv[1]
     release_repository = sys.argv[2]
 
-    # read GITHUB_TOKEN if provided (needed for private repositories only)
-    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", None)
-    
+    # GITHUB_TOKEN is optional for public repos; use it when present.
+    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+    if not GITHUB_TOKEN:
+        print("GITHUB_TOKEN is not set. Proceeding without authentication.")
     print(f"Fetching release info for {release_tag} from {release_repository}")
     # Determine if the release is a beta release.
     beta = any(keyword in release_tag.lower() for keyword in ["beta", "alpha", "rc"])
@@ -93,6 +95,7 @@ def main():
 
     # Parse the JSON data
     release_info = json.loads(data.decode("utf-8"))
+    release_summary = utils.extract_summary_section(release_info.get("body", ""))
 
     assets = release_info.get("assets", [])
     
@@ -130,6 +133,7 @@ def main():
             beta,
             release_repository,
             GITHUB_TOKEN,
+            release_summary,
         )
 
 

--- a/scripts/utils/utils.py
+++ b/scripts/utils/utils.py
@@ -3,13 +3,34 @@ import json
 import shutil
 import sys
 import urllib.request
+import re
 
+
+def extract_summary_section(release_body):
+    if not release_body:
+        return None
+
+    header_match = re.search(r"(?im)^\s{0,3}#{1,6}\s+summary\s*$", release_body)
+    if not header_match:
+        return None
+
+    section_start = header_match.end()
+    remaining_body = release_body[section_start:]
+    next_header_match = re.search(r"(?im)^\s{0,3}#{1,6}\s+.+$", remaining_body)
+
+    if next_header_match:
+        section_content = remaining_body[:next_header_match.start()]
+    else:
+        section_content = remaining_body
+
+    summary = section_content.strip()
+    return summary if summary else None
 
 def extract_variant(BASE_NAME):
     parts = BASE_NAME.split(".")
     return parts[1] if len(parts) > 1 else ""
 
-def make_manifest(BASE_NAME, release_tag, esphome_firmware_repository, OTA_MD5, MANIFEST_FILE_DIR, beta, FIRMWARE_FILE_DIR):
+def make_manifest(BASE_NAME, release_tag, esphome_firmware_repository, OTA_MD5, MANIFEST_FILE_DIR, beta, FIRMWARE_FILE_DIR, summary=None):
     # Create the manifest file directory if it does not exist
     if not os.path.exists(MANIFEST_FILE_DIR):
         os.makedirs(MANIFEST_FILE_DIR)
@@ -29,7 +50,7 @@ def make_manifest(BASE_NAME, release_tag, esphome_firmware_repository, OTA_MD5, 
                 "ota": {
                     "path": f"{DIR_NAME}/{BASE_NAME}.ota.bin",
                     "md5": OTA_MD5,
-                    "summary": f"ESPHome Firmware for {BASE_NAME}",
+                    "summary": summary or f"ESPHome Firmware for {BASE_NAME}",
                     "release_url": f"https://github.com/{esphome_firmware_repository}/releases/tag/{release_tag}/"
                 },
                 "parts": [
@@ -62,12 +83,12 @@ def error_exit(message):
     print(message, file=sys.stderr)
     sys.exit(1)
 
-def get_release_info(release_tag, release_repository, GITHUB_TOKEN):
+def get_release_info(release_tag, release_repository, GITHUB_TOKEN=None):
     # Fetch the assets from the GitHub API
     api_url = f"https://api.github.com/repos/{release_repository}/releases/tags/{release_tag}"
     request = urllib.request.Request(api_url)
     request.add_header('Accept', 'application/vnd.github+json')
-    if not GITHUB_TOKEN is None:
+    if GITHUB_TOKEN:
         request.add_header('Authorization', f'Bearer {GITHUB_TOKEN}')
 
     try:


### PR DESCRIPTION
This modification to the release assets creating script now check whether the body of the release description contains a `summary` section/title. If so the content of this section is put into the manifest's summary field.